### PR TITLE
🧹 Remove unused itertools import from numberOfsequence.py

### DIFF
--- a/datastructure/numberOfsequence.py
+++ b/datastructure/numberOfsequence.py
@@ -1,6 +1,5 @@
 #!/bin/python3
 # https://www.hackerrank.com/contests/w22/challenges/number-of-sequences/
-import itertools
 
 '''
 So for those who are confused, here's an explanation of the problem that makes sense for me (and hopefully will help you too):


### PR DESCRIPTION
🎯 **What:** Removed unused `itertools` import from `datastructure/numberOfsequence.py`.
💡 **Why:** To improve code maintainability and cleanliness by removing unnecessary dependencies and dead code.
✅ **Verification:** Compiled the script via `python3 -m py_compile` to ensure no syntax errors were introduced, and passed a code review which confirmed the logic is intact.
✨ **Result:** A cleaner codebase with fewer unused imports.

---
*PR created automatically by Jules for task [3654227925737688302](https://jules.google.com/task/3654227925737688302) started by @mrdat0194*