### PR TITLE
🔒 Security: Fix Hardcoded API Key in exchange_test.py

### DIFF
--- a/adHoc/web/exchange_test.py
+++ b/adHoc/web/exchange_test.py
@@ -1,7 +1,8 @@
+import os
 import requests
 import datetime
 
-api_key = "xx6nnEoT0ziwKoydsNbLVrYISR1WpfmG"
+api_key = os.environ.get("EXCHANGE_API_KEY")
 
 # Extract base_currency and symbols from request parameters (if provided)
 # base_currency = requests.args.get("base_currency", "USD")


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded API key from `adHoc/web/exchange_test.py`.
⚠️ **Risk:** Hardcoded API keys present a critical security vulnerability as they can be easily extracted from source control, leading to unauthorized use, potential quota exhaustion, and financial loss.
🛡️ **Solution:** Modified the script to read the API key from the `EXCHANGE_API_KEY` environment variable using `os.environ.get()`, aligning with security best practices for managing secrets.

---
*PR created automatically by Jules for task [10645768147169831958](https://jules.google.com/task/10645768147169831958) started by @mrdat0194*