### PR TITLE
🧪 Add tests for decode_fourcc function in openCV_simple.py

### DIFF
--- a/my_functions/open_cv_function/openCV_simple.py
+++ b/my_functions/open_cv_function/openCV_simple.py
@@ -1,6 +1,6 @@
 import cv2
 import time
-from my_functions import timer
+from my_functions.timer import timer
 
 @timer
 def decode_fourcc(v: int):

--- a/my_functions/open_cv_function/test/test_openCV_simple.py
+++ b/my_functions/open_cv_function/test/test_openCV_simple.py
@@ -1,0 +1,41 @@
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Mock cv2 because the environment may not have it installed
+sys.modules['cv2'] = MagicMock()
+
+# Ensure the root directory is in the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from my_functions.open_cv_function.openCV_simple import decode_fourcc
+
+class TestDecodeFourcc(unittest.TestCase):
+    def test_decode_fourcc_avc1(self):
+        # 828601953 -> 'avc1'
+        self.assertEqual(decode_fourcc(828601953), 'avc1')
+
+    def test_decode_fourcc_mp4v(self):
+        # 1983148141 -> 'mp4v'
+        self.assertEqual(decode_fourcc(1983148141), 'mp4v')
+
+    def test_decode_fourcc_av01(self):
+        # 825259617 -> 'av01'
+        self.assertEqual(decode_fourcc(825259617), 'av01')
+
+    def test_decode_fourcc_string_input(self):
+        # The function converts input to int, so a string should work if it contains a valid int.
+        self.assertEqual(decode_fourcc("828601953"), 'avc1')
+
+    def test_decode_fourcc_float_input(self):
+        # The function converts input to int
+        self.assertEqual(decode_fourcc(828601953.0), 'avc1')
+
+    def test_decode_fourcc_invalid_input(self):
+        # Should raise ValueError for string that cannot be cast to int
+        with self.assertRaises(ValueError):
+            decode_fourcc("invalid")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** This PR adds test coverage to `my_functions/open_cv_function/openCV_simple.py` for the `decode_fourcc` function. The function translates an integer value into a four-character string code (FOURCC).

📊 **Coverage:** The tests verify the happy path by checking correctly translated integer values such as `avc1`, `av01`, and `mp4v`. They also cover inputs consisting of string representations of numbers, float values, and verify a ValueError exception on invalid strings.

✨ **Result:** Test coverage for `decode_fourcc` is significantly improved. A bug where `timer.py` was being incorrectly imported as a function was also fixed to allow tests to run correctly.

---
*PR created automatically by Jules for task [1566277420947985230](https://jules.google.com/task/1566277420947985230) started by @mrdat0194*