### PR TITLE
🔒 Fix hardcoded API key in exchange_test.py

### DIFF
--- a/adHoc/web/exchange_test.py
+++ b/adHoc/web/exchange_test.py
@@ -1,17 +1,20 @@
 import requests
-import datetime
+import os
 
-api_key = "xx6nnEoT0ziwKoydsNbLVrYISR1WpfmG"
+api_key = os.environ.get("API_KEY")
 
 # Extract base_currency and symbols from request parameters (if provided)
 # base_currency = requests.args.get("base_currency", "USD")
 # symbols = requests.args.get("symbols", "VND")
 
-base_currency = 'USD'
-symbols = 'VND'
+base_currency = "USD"
+symbols = "VND"
 
 # Construct the API URL
-url = f"https://api.apilayer.com/exchangerates_data/latest?symbols={symbols}&base={base_currency}"
+url = (
+    "https://api.apilayer.com/exchangerates_data/latest?"
+    f"symbols={symbols}&base={base_currency}"
+)
 
 # Make the HTTP GET request with headers
 headers = {"apikey": api_key}
@@ -19,10 +22,10 @@ response = requests.get(url, headers=headers)
 
 # Check for successful response
 if response.status_code == 200:
-  data = response.json()
-  print(data)
+    data = response.json()
+    print(data)
 
-  # Extract and format exchange rate for BigQuery
-  exchange_rate = data.get("rates", {}).get(symbols, None)
-  if exchange_rate is None:
-      print( f"Error: Currency '{symbols}' not found in response.")
+    # Extract and format exchange rate for BigQuery
+    exchange_rate = data.get("rates", {}).get(symbols, None)
+    if exchange_rate is None:
+        print(f"Error: Currency '{symbols}' not found in response.")


### PR DESCRIPTION
🎯 **What:** Removed a hardcoded API key from `adHoc/web/exchange_test.py`.
⚠️ **Risk:** Hardcoded API keys pose a security vulnerability. If the repository is exposed, attackers can extract the credentials and abuse the exchange rate API service on behalf of the credential owner, leading to financial loss or exhaustion of API quotas.
🛡️ **Solution:** Modified the script to read the API key from the `API_KEY` environment variable instead of using a hardcoded string literal. Cleaned up an unused `datetime` import and formatted the file with `black` and `flake8` to fix a line length violation.

---
*PR created automatically by Jules for task [3233446475464257040](https://jules.google.com/task/3233446475464257040) started by @mrdat0194*