### PR TITLE
🔒 Fix hardcoded API key vulnerability in adHoc web scripts

### DIFF
--- a/adHoc/web/api_exchange_rate.py
+++ b/adHoc/web/api_exchange_rate.py
@@ -1,8 +1,9 @@
 import datetime
 import requests
+import os
 
 def get_exchange_rate(base_currency, symbols, date):
-    api_key = "jNC2YcPZXWCYJIAqDQJyvxMW23VgzK3x"
+    api_key = os.environ.get("EXCHANGE_RATE_API_KEY")
     headers = {"apikey": api_key}
     url = f"https://api.apilayer.com/exchangerates_data/{date}?symbols={symbols}&base={base_currency}"
     response = requests.get(url, headers=headers)

--- a/adHoc/web/exchange_test.py
+++ b/adHoc/web/exchange_test.py
@@ -1,7 +1,8 @@
 import requests
 import datetime
+import os
 
-api_key = "xx6nnEoT0ziwKoydsNbLVrYISR1WpfmG"
+api_key = os.environ.get("EXCHANGE_RATE_API_KEY")
 
 # Extract base_currency and symbols from request parameters (if provided)
 # base_currency = requests.args.get("base_currency", "USD")


### PR DESCRIPTION
🎯 **What:** Hardcoded API keys were present as plaintext strings in `adHoc/web/api_exchange_rate.py` and `adHoc/web/exchange_test.py`.
⚠️ **Risk:** Anyone with access to the source code could steal these API keys and use the apilayer.com exchange rate service, exhausting the subscription rate limits and potentially causing financial impact or denial of service to the legitimate application.
🛡️ **Solution:** Modified both scripts to import `os` and retrieve the API key dynamically from an environment variable (`EXCHANGE_RATE_API_KEY`). This prevents secret leakage and allows secure runtime configuration.

---
*PR created automatically by Jules for task [13878738017590584870](https://jules.google.com/task/13878738017590584870) started by @mrdat0194*