### PR TITLE
🧹 Remove unused imports in MLModel/model/ada_boost.py

### DIFF
--- a/MLModel/model/ada_boost.py
+++ b/MLModel/model/ada_boost.py
@@ -1,6 +1,6 @@
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import classification_report
-from sklearn.ensemble import AdaBoostClassifier, GradientBoostingClassifier, BaggingClassifier, VotingClassifier
+from sklearn.ensemble import AdaBoostClassifier, VotingClassifier
 
 # from tensorflow.python.util import deprecation
 from sklearn.linear_model import LogisticRegression


### PR DESCRIPTION
🎯 **What:** Removed unused imports `GradientBoostingClassifier` and `BaggingClassifier` from `MLModel/model/ada_boost.py`.
💡 **Why:** These imports were unnecessary, keeping the code clean and improving maintainability.
✅ **Verification:** Verified that the python module imports cleanly and successfully with `PYTHONPATH=. python -c "from MLModel.model.ada_boost import model_ada"`. Verified the changes don't introduce regressions in existing test suite.
✨ **Result:** A slightly cleaner and faster loading module.

---
*PR created automatically by Jules for task [12851136446419931005](https://jules.google.com/task/12851136446419931005) started by @mrdat0194*