### PR TITLE
🧹 Remove unused `deprecation` import from logistic_regression.py

### DIFF
--- a/MLModel/model/logistic_regression.py
+++ b/MLModel/model/logistic_regression.py
@@ -1,6 +1,5 @@
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import classification_report
-from tensorflow.python.util import deprecation
 from sklearn.metrics import confusion_matrix
 import tensorflow as tf
 import os


### PR DESCRIPTION
🎯 **What:** Removed the unused `from tensorflow.python.util import deprecation` import from `MLModel/model/logistic_regression.py`.
💡 **Why:** This improves maintainability and readability by cleaning up dead code and removing an unnecessary dependency on a specific internal TensorFlow utility in this file.
✅ **Verification:** Verified by importing the module directly to ensure no runtime errors are introduced. The existing unit tests in `MLModel/run` have broken dependencies and missing file fixtures in the repo, but the specific file edited does not break on import or syntax checks.
✨ **Result:** A cleaner file with fewer unneeded imports.

---
*PR created automatically by Jules for task [16502268122142601188](https://jules.google.com/task/16502268122142601188) started by @mrdat0194*