### PR TITLE
🧹 Remove unused ActionChains import in VOA.py

### DIFF
--- a/helper_functions/auto_test_elearning/VOA.py
+++ b/helper_functions/auto_test_elearning/VOA.py
@@ -1,6 +1,5 @@
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver import ActionChains
 import time
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By


### PR DESCRIPTION
🎯 **What:** Removed unused `ActionChains` import from `helper_functions/auto_test_elearning/VOA.py`.
💡 **Why:** To improve code clarity and maintainability by removing dead code.
✅ **Verification:**
- Verified via `grep` that `ActionChains` is not used anywhere else in `VOA.py`.
- Ran `python3 -m py_compile` to ensure no syntax errors were introduced.
- Ran the adjacent test script `elearning_test.py` to ensure that pre-existing behavior remains exactly the same and no regressions were introduced.
✨ **Result:** A cleaner script file without unused imports.

---
*PR created automatically by Jules for task [13381637129811134359](https://jules.google.com/task/13381637129811134359) started by @mrdat0194*