### PR TITLE
fix: Correct y-axis bounds for matrix visualizations in plot_lib.py

### DIFF
--- a/MLModel/model/res/plot_lib.py
+++ b/MLModel/model/res/plot_lib.py
@@ -78,7 +78,7 @@ def show_mat(mat, vect, prod, threshold=-1):
     fig.colorbar(cax3, ax=ax3)
 
     # Fix y-axis limits
-    ax1.set_ylim(bottom=max(len(prod), len(vect)) - 0.5)
+    ax1.set_ylim(bottom=max(len(prod), len(vect)) - 0.5, top=-0.5)
 
 
 colors = dict(


### PR DESCRIPTION
- Updated `set_ylim()` call in `show_mat()` within `MLModel/model/res/plot_lib.py` to include `top=-0.5`
- Prevents auto-scaling cutoff of the top matrix elements in Matplotlib `matshow` visualizations when comparing differently sized tensors

---
*PR created automatically by Jules for task [2372799852192942937](https://jules.google.com/task/2372799852192942937) started by @mrdat0194*