### PR TITLE
🧹 Remove unused import BorderlineSMOTE in MLModel Classification script

### DIFF
--- a/MLModel/model/code/Chapter 5 - Classification.py
+++ b/MLModel/model/code/Chapter 5 - Classification.py
@@ -19,7 +19,7 @@ from sklearn.metrics import roc_curve, accuracy_score, roc_auc_score
 
 import statsmodels.api as sm
 
-from imblearn.over_sampling import SMOTE, ADASYN, BorderlineSMOTE
+from imblearn.over_sampling import SMOTE, ADASYN
 from pygam import LinearGAM, s, f, l
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused import `BorderlineSMOTE` from `imblearn.over_sampling` in `MLModel/model/code/Chapter 5 - Classification.py`.
💡 **Why:** This improves maintainability by removing unnecessary dependencies and dead code, leading to cleaner and more readable code.
✅ **Verification:** Verified that the import was removed via `cat` and `grep`. Ran a syntax check using `python -m py_compile`. Executed tests via `python -m pytest MLModel/` and confirmed that any existing failures are pre-existing issues unrelated to this change. Code review approved the change.
✨ **Result:** The codebase is slightly cleaner and more maintainable with no change in functionality.

---
*PR created automatically by Jules for task [2833856351243608689](https://jules.google.com/task/2833856351243608689) started by @mrdat0194*