### PR TITLE
🧹 Remove unused import in test_bayes_regression.py

### DIFF
--- a/MLModel/run/test_bayes_regression.py
+++ b/MLModel/run/test_bayes_regression.py
@@ -1,4 +1,3 @@
-from MLModel.data_pipeline import data_helper
 from MLModel.model import bayesian
 import pandas as pd
 import warnings


### PR DESCRIPTION
🎯 **What:** Removed unused import `data_helper` from `MLModel/run/test_bayes_regression.py`.
💡 **Why:** Improves code hygiene and readability by removing dead code.
✅ **Verification:** Ran test script and diffed the output against the baseline before the change to confirm it does not introduce any new regressions.
✨ **Result:** A cleaner script that avoids loading an unused pipeline module.

---
*PR created automatically by Jules for task [17306299132090712296](https://jules.google.com/task/17306299132090712296) started by @mrdat0194*