### PR TITLE
Import LangChain dependencies in partB/app.py

### DIFF
--- a/adHoc/Testing/candidate_package/candidate_package/partB/app.py
+++ b/adHoc/Testing/candidate_package/candidate_package/partB/app.py
@@ -15,11 +15,10 @@ import os
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-# TODO (B1): import LangChain / embedding / vector store dependencies
-# e.g. from langchain_community.document_loaders import TextLoader
-#      from langchain.text_splitter import RecursiveCharacterTextSplitter
-#      from langchain_openai import OpenAIEmbeddings, ChatOpenAI
-#      from langchain_community.vectorstores import FAISS
+from langchain_community.document_loaders import TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+from langchain_community.vectorstores import FAISS
 
 app = FastAPI(title="EDB Policy Q&A", version="1.0")
 

--- a/adHoc/Testing/candidate_package/candidate_package/partB/requirements.txt
+++ b/adHoc/Testing/candidate_package/candidate_package/partB/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
-pydantic==2.7.1
+pydantic>=2.7.4
 langchain==0.2.6
 langchain-community==0.2.6
 langchain-openai==0.1.13


### PR DESCRIPTION
I have imported the necessary LangChain dependencies in `adHoc/Testing/candidate_package/candidate_package/partB/app.py` as requested. 

Additionally, I updated `adHoc/Testing/candidate_package/candidate_package/partB/requirements.txt` to use `pydantic>=2.7.4` because the original `pydantic==2.7.1` was causing a dependency conflict with `langchain-core` (version 0.2.43) on the current Python 3.12.13 environment.

I verified the solution by:
1. Installing the requirements.
2. Running a Python command to ensure all modules can be imported without error.
3. Starting the FastAPI server and confirming it reached the 'Application startup complete' state.
4. Testing the `/health` and `/ask` endpoints using `curl` to ensure the application is correctly initialized and handling requests (returning 503 for `/ask` as the vector store is not yet implemented, which is the expected behavior at this stage).

---
*PR created automatically by Jules for task [6598338441563213434](https://jules.google.com/task/6598338441563213434) started by @mrdat0194*