### PR TITLE
🧹 Fix invalid escape sequence in drowsiness detection script

### DIFF
--- a/my_functions/open_cv_function/drowsiness-detection/detect_drowsiness.py
+++ b/my_functions/open_cv_function/drowsiness-detection/detect_drowsiness.py
@@ -45,7 +45,7 @@ ap.add_argument("-w", "--webcam", type=int, default=0,
 
 args = {}
 
-args["shape_predictor"] = 'C:\Hello\AI\my_functions\open_cv_function\drowsiness-detection\shape_predictor_68_face_landmarks.dat'
+args["shape_predictor"] = r'C:\Hello\AI\my_functions\open_cv_function\drowsiness-detection\shape_predictor_68_face_landmarks.dat'
 
 #args = vars(ap.parse_args())
  


### PR DESCRIPTION
🎯 **What:** Fixed an invalid escape sequence in a hardcoded Windows path inside `detect_drowsiness.py`.
💡 **Why:** By changing the string to a raw string (using the `r` prefix), we prevent Python from treating backslashes as escape sequences, avoiding `SyntaxWarning: invalid escape sequence` on modern Python versions (e.g., Python 3.12).
✅ **Verification:** Verified by running `python3 -m py_compile` to ensure the syntax warning is no longer emitted.
✨ **Result:** The code no longer raises syntax warnings and avoids subtle bugs if path elements start with characters like `\n` or `\t`.

---
*PR created automatically by Jules for task [14541119004823479873](https://jules.google.com/task/14541119004823479873) started by @mrdat0194*