### PR TITLE
🧹 Fix IndentationError in generate_task

### DIFF
--- a/main_def/models/crawler_type.py
+++ b/main_def/models/crawler_type.py
@@ -38,5 +38,6 @@ class when_exist:
 
 
 def generate_task(action_id: str, object_id: str, task_detail: dict) -> str:
+    pass
 
 


### PR DESCRIPTION
🎯 **What:** Fixed an `IndentationError` in `main_def/models/crawler_type.py` by adding a `pass` statement to the empty `generate_task` function.
💡 **Why:** Empty function definitions in Python cause syntax errors (`IndentationError` or `SyntaxError: unexpected EOF while parsing`) which prevents the module from being compiled or imported. Adding `pass` resolves this issue and allows the module to be used.
✅ **Verification:** Ran `python3 -m py_compile main_def/models/crawler_type.py` and confirmed there are no longer any syntax errors.
✨ **Result:** The codebase is healthier and `main_def/models/crawler_type.py` is now syntactically valid.

---
*PR created automatically by Jules for task [8320654290968531244](https://jules.google.com/task/8320654290968531244) started by @mrdat0194*