### PR TITLE
🧪 Add test for get_token_set_ratio

### DIFF
--- a/my_functions/text_similarity/test_text_similarity.py
+++ b/my_functions/text_similarity/test_text_similarity.py
@@ -94,5 +94,16 @@ class TestTextSimilarity(unittest.TestCase):
         mock_fuzz.token_set_ratio.assert_called_once_with("", "")
         self.assertEqual(result, 0)
 
+    @patch('my_functions.text_similarity.text_similarity.unidecode.unidecode')
+    def test_get_token_set_ratio_integration(self, mock_uni):
+        """Test get_token_set_ratio with actual unmocked string_reformat functionality."""
+        mock_uni.side_effect = lambda x: x
+        mock_fuzz.token_set_ratio.return_value = 85
+
+        result = get_token_set_ratio("Hello World!", "hello world")
+
+        mock_fuzz.token_set_ratio.assert_called_once_with("hello world", "hello world")
+        self.assertEqual(result, 85)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: `get_token_set_ratio` lacked a comprehensive integration test that checked its interaction with `string_reformat` under normal usage.
📊 **Coverage:** The happy path integration using valid input strings.
✨ **Result:** Enhanced test suite and coverage to ensure that refactoring the data pipeline doesn't unexpectedly break `get_token_set_ratio`.

---
*PR created automatically by Jules for task [14902658018041217369](https://jules.google.com/task/14902658018041217369) started by @mrdat0194*