### PR TITLE
🧪 Add tests and fix modern Pandas bug in append_df_to_excel

### DIFF
--- a/my_functions/Ongoing/Complete_Function.py
+++ b/my_functions/Ongoing/Complete_Function.py
@@ -196,46 +196,36 @@ def append_df_to_excel(filename, df, sheet_name='Sheet1', startrow=None,
     Returns: None
 
     """
+    import os
     from openpyxl import load_workbook
 
-    # ignore [engine] parameter if it was passed
     if 'engine' in to_excel_kwargs:
         to_excel_kwargs.pop('engine')
 
-    writer = pd.ExcelWriter(filename, engine='openpyxl')
+    file_exists = os.path.isfile(filename)
 
-    try:
-        # try to open an existing workbook
-        writer.book = load_workbook(filename)
+    if not file_exists:
+        writer = pd.ExcelWriter(filename, engine='openpyxl')
+        df.to_excel(writer, sheet_name=sheet_name, startrow=startrow if startrow is not None else 0, **to_excel_kwargs)
+        writer.close()
+    else:
+        book = load_workbook(filename)
+        if startrow is None and sheet_name in book.sheetnames:
+            startrow = book[sheet_name].max_row
+        elif startrow is None:
+            startrow = 0
 
-        # get the last row in the existing Excel sheet
-        # if it was not specified explicitly
-        if startrow is None and sheet_name in writer.book.sheetnames:
-            startrow = writer.book[sheet_name].max_row
+        if truncate_sheet:
+            startrow = 0
 
-        # truncate sheet
-        if truncate_sheet and sheet_name in writer.book.sheetnames:
-            # index of [sheet_name] sheet
-            idx = writer.book.sheetnames.index(sheet_name)
-            # remove [sheet_name]
-            writer.book.remove(writer.book.worksheets[idx])
-            # create an empty sheet [sheet_name] using old index
-            writer.book.create_sheet(sheet_name, idx)
+        kwargs = {'engine': 'openpyxl', 'mode': 'a'}
+        if truncate_sheet:
+            kwargs['if_sheet_exists'] = 'replace'
+        else:
+            kwargs['if_sheet_exists'] = 'overlay'
 
-        # copy existing sheets
-        writer.sheets = {ws.title:ws for ws in writer.book.worksheets}
-    except FileNotFoundError:
-        # file does not exist yet, we will create it
-        pass
-
-    if startrow is None:
-        startrow = 0
-
-    # write out the new sheet
-    df.to_excel(writer, sheet_name, startrow=startrow, **to_excel_kwargs)
-
-    # save the workbook
-    writer.save()
+        with pd.ExcelWriter(filename, **kwargs) as writer:
+            df.to_excel(writer, sheet_name=sheet_name, startrow=startrow, **to_excel_kwargs)
 
 def Extract_Diff_id(Event_Category, Var1, tota_FB_promotion, Question_user):
     tota_FB_promotion = tota_FB_promotion.copy()

--- a/my_functions/Ongoing/test_Complete_Function.py
+++ b/my_functions/Ongoing/test_Complete_Function.py
@@ -1,0 +1,54 @@
+import unittest
+import pandas as pd
+import numpy as np
+import os
+from unittest.mock import patch, MagicMock
+from Complete_Function import append_df_to_excel
+
+class TestCompleteFunction(unittest.TestCase):
+    def setUp(self):
+        self.filename = "test_output.xlsx"
+        self.df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
+    def test_append_df_to_excel_new_file(self):
+        # Test creating a new file
+        append_df_to_excel(self.filename, self.df, sheet_name='Sheet1')
+        self.assertTrue(os.path.exists(self.filename))
+
+        # Verify contents
+        read_df = pd.read_excel(self.filename, sheet_name='Sheet1', index_col=0)
+        pd.testing.assert_frame_equal(self.df, read_df)
+
+    def test_append_df_to_excel_append(self):
+        # Create initial file
+        append_df_to_excel(self.filename, self.df, sheet_name='Sheet1')
+
+        # Append second dataframe
+        df2 = pd.DataFrame({'A': [5, 6], 'B': [7, 8]})
+        append_df_to_excel(self.filename, df2, sheet_name='Sheet1', header=False)
+
+        # Verify contents
+        read_df = pd.read_excel(self.filename, sheet_name='Sheet1', index_col=0)
+        expected_df = pd.concat([self.df, df2], ignore_index=True)
+        # Note: the index of read_df won't be clean because of how appending works,
+        # but the values should match
+        np.testing.assert_array_equal(read_df.values, expected_df.values)
+
+    def test_append_df_to_excel_truncate(self):
+        # Create initial file
+        append_df_to_excel(self.filename, self.df, sheet_name='Sheet1')
+
+        # Truncate and write new dataframe
+        df2 = pd.DataFrame({'C': [9, 10], 'D': [11, 12]})
+        append_df_to_excel(self.filename, df2, sheet_name='Sheet1', truncate_sheet=True)
+
+        # Verify contents
+        read_df = pd.read_excel(self.filename, sheet_name='Sheet1', index_col=0)
+        pd.testing.assert_frame_equal(df2, read_df)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `append_df_to_excel` function had a fatal bug in modern Pandas environments where it immediately truncated existing files to 0 bytes before attempting to load them, leading to `BadZipFile` errors. We refactored it to use Pandas' native append mode and `if_sheet_exists` mechanisms, and created a test suite.
📊 **Coverage:** Added coverage for creating new Excel files, appending to existing sheets (overlaying), and truncating (replacing) existing sheets.
✨ **Result:** The function is now reliable under modern Pandas, and is protected by tests against regression.

---
*PR created automatically by Jules for task [17106977611217231230](https://jules.google.com/task/17106977611217231230) started by @mrdat0194*