### PR TITLE
🧪 Add tests for get_config in Complete_Function.py

### DIFF
--- a/my_functions/Ongoing/test_Complete_Function.py
+++ b/my_functions/Ongoing/test_Complete_Function.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch, mock_open
+import bcrypt
+
+from my_functions.Ongoing.Complete_Function import get_config
+
+class TestCompleteFunction(unittest.TestCase):
+    @patch('builtins.input', side_effect=['test_user', 'secret', 'test_key'])
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.load')
+    @patch('my_functions.Ongoing.Complete_Function.MAIN_DIR', '/tmp')
+    def test_get_config_success(self, mock_json_load, mock_file, mock_input):
+        # Create a real hashed password for 'secret'
+        hashed_pw = bcrypt.hashpw(b'secret', bcrypt.gensalt()).decode('utf-8')
+        mock_json_load.return_value = {
+            'test_user': hashed_pw,
+            'test_key': 'test_value'
+        }
+
+        result = get_config()
+        self.assertEqual(result, 'test_value')
+
+    @patch('builtins.input', side_effect=['test_user', 'wrong_secret', 'test_key'])
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.load')
+    @patch('my_functions.Ongoing.Complete_Function.MAIN_DIR', '/tmp')
+    @patch('builtins.print')
+    def test_get_config_wrong_password(self, mock_print, mock_json_load, mock_file, mock_input):
+        hashed_pw = bcrypt.hashpw(b'secret', bcrypt.gensalt()).decode('utf-8')
+        mock_json_load.return_value = {
+            'test_user': hashed_pw,
+            'test_key': 'test_value'
+        }
+
+        result = get_config()
+        self.assertIsNone(result)
+        mock_print.assert_called_with("Please let it go!")
+
+    @patch('builtins.input', side_effect=['wrong_user', 'secret', 'test_key'])
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.load')
+    @patch('my_functions.Ongoing.Complete_Function.MAIN_DIR', '/tmp')
+    @patch('builtins.print')
+    def test_get_config_wrong_user(self, mock_print, mock_json_load, mock_file, mock_input):
+        hashed_pw = bcrypt.hashpw(b'secret', bcrypt.gensalt()).decode('utf-8')
+        mock_json_load.return_value = {
+            'test_user': hashed_pw,
+            'test_key': 'test_value'
+        }
+
+        result = get_config()
+        self.assertIsNone(result)
+        mock_print.assert_called_with("Please let it go!")
+
+    @patch('builtins.input', side_effect=['test_user', 'secret', 'test_key'])
+    @patch('builtins.open', side_effect=IOError)
+    @patch('my_functions.Ongoing.Complete_Function.MAIN_DIR', '/tmp')
+    @patch('builtins.print')
+    def test_get_config_ioerror(self, mock_print, mock_file, mock_input):
+        with self.assertRaises(UnboundLocalError):
+            # In the function, if IOError occurs, users_dict is not defined,
+            # and it will crash at: hashed = users_dict.get(username)
+            get_config()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests for the `get_config` function in `my_functions/Ongoing/Complete_Function.py`.
📊 **Coverage:** Covered successful configuration retrieval, incorrect password handling, nonexistent user handling, and a known `UnboundLocalError` that occurs upon `IOError` during JSON reading.
✨ **Result:** Improved test coverage for `get_config`, mocking file reading, `input`, and `json.load` to test it deterministically without side effects.

---
*PR created automatically by Jules for task [2378290203159162016](https://jules.google.com/task/2378290203159162016) started by @mrdat0194*