### PR TITLE
🔒 Fix insecure deserialization in quick_drive.py

### DIFF
--- a/main_def/ggl_api/google_spreadsheet_api/quick_drive.py
+++ b/main_def/ggl_api/google_spreadsheet_api/quick_drive.py
@@ -1,10 +1,10 @@
 # Cannot use
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import credentials, tokens
 
 # If modifying these scopes, delete the file token.pickle.
@@ -15,12 +15,12 @@ def main():
     Prints the names and ids of the first 10 files the user has access to.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+    json_tokens = tokens.replace('.pickle', '.json')
+    if os.path.exists(json_tokens):
+        creds = Credentials.from_authorized_user_file(json_tokens, SCOPES)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -30,8 +30,9 @@ def main():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        if creds:
+            with open(json_tokens, 'w') as token:
+                token.write(creds.to_json())
 
     service = build('drive', 'v3', credentials=creds)
 

--- a/test_quick_drive.py
+++ b/test_quick_drive.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+from main_def.ggl_api.google_spreadsheet_api.quick_drive import main
+
+class TestQuickDrive(unittest.TestCase):
+    @patch('main_def.ggl_api.google_spreadsheet_api.quick_drive.os.path.exists')
+    @patch('main_def.ggl_api.google_spreadsheet_api.quick_drive.Credentials.from_authorized_user_file')
+    @patch('main_def.ggl_api.google_spreadsheet_api.quick_drive.build')
+    def test_main_with_valid_creds(self, mock_build, mock_load, mock_exists):
+        mock_exists.return_value = True
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_load.return_value = mock_creds
+
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        mock_service.files().list().execute.return_value = {'files': [{'name': 'test', 'id': '123'}]}
+
+        with patch('builtins.open', mock_open(read_data=b'data')):
+            main()
+
+        mock_build.assert_called_once()
+        self.assertTrue(mock_service.files().list.called)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `pickle.load()` function was used to load Google API credentials from `token.pickle`, which is vulnerable to insecure deserialization if the file is tampered with.
⚠️ **Risk:** An attacker could craft a malicious `token.pickle` file which, when loaded by this script, could execute arbitrary code on the host machine.
🛡️ **Solution:** Switched to the Google-supported JSON serialization by utilizing `Credentials.from_authorized_user_file()` for loading and `creds.to_json()` for saving the token. The token file path is seamlessly adapted to look for/save a `.json` extension instead of `.pickle`. Unused imports were removed.

---
*PR created automatically by Jules for task [12699635147694529126](https://jules.google.com/task/12699635147694529126) started by @mrdat0194*