### PR TITLE
🔒 Fix insecure deserialization in token loading

### DIFF
--- a/main_def/__init__.py
+++ b/main_def/__init__.py
@@ -1,3 +1,4 @@
+from google.oauth2.credentials import Credentials
 import os
 
 MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -5,7 +6,7 @@ query_path = os.path.join(MAIN_DIR, "info", "query.txt")
 data_trial = os.path.join(MAIN_DIR, "data", "Gonj")
 config_sql = os.path.join(MAIN_DIR, "sql_con", "database.json")
 credentials = os.path.join(MAIN_DIR, "ggl_api", "kasa", "GoogleAds", "credentials.json")
-tokens = os.path.join(MAIN_DIR, "ggl_api", "token.pickle")
+tokens = os.path.join(MAIN_DIR, "ggl_api", "token.json")
 
 # function_utils = os.path.join(MAIN_DIR,"Complete_Function.py")
 # exec(open(function_utils).read())
@@ -15,7 +16,7 @@ tokens = os.path.join(MAIN_DIR, "ggl_api", "token.pickle")
 # MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
 # credentials = os.path.join(MAIN_DIR, "ggl_api", "credentials.json")
 # client_secret_store = os.path.join(MAIN_DIR, "ggl_api", "client_secret_store.json")
-# tokens = os.path.join(MAIN_DIR, "ggl_api", "token.pickle")
+# tokens = os.path.join(MAIN_DIR, "ggl_api", "token.json")
 #
 # save_path_sheet = os.path.join(MAIN_DIR, "ggl_api", "Automate_data_model", "info", "to_sheet.csv")
 # get_url = os.path.join(MAIN_DIR, "ggl_api", "Automate_data_model", "info","url.csv")

--- a/main_def/ggl_api/Automate_data_model/copy_sheet_template.py
+++ b/main_def/ggl_api/Automate_data_model/copy_sheet_template.py
@@ -1,8 +1,8 @@
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, save_path_sheet, title_sheet, title_test_plan
 
 
@@ -13,12 +13,11 @@ SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googlea
 Prints values from a sample spreadsheet.80
 """
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -28,8 +27,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=8080)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
 service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/Automate_data_model/copy_slide_template.py
+++ b/main_def/ggl_api/Automate_data_model/copy_slide_template.py
@@ -2,20 +2,18 @@ from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 
 import os
 from main_def import MAIN_DIR, credentials, tokens
-import pickle
-
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly', 'https://www.googleapis.com/auth/drive.file']
 
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -25,8 +23,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=0)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 def copy_presentation(presentation_id, copy_title):
     """
     Creates the copy Presentation the user has access to.

--- a/main_def/ggl_api/Automate_data_model/create_slide_image.py
+++ b/main_def/ggl_api/Automate_data_model/create_slide_image.py
@@ -3,10 +3,10 @@ from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, FIX_SLIDE_ID,new_slide, target_folder_id, get_url, slide_image_path
 import csv
 
-import pickle
 import os.path
 import time
 import pandas as pd
@@ -120,18 +120,17 @@ def create_image(presentation_id, new_slide, target_folder_id):
     for guides on implementing OAuth2 for the application.
     """
 
-    # If modifying these scopes, delete the file token.pickle.
+    # If modifying these scopes, delete the file token.json.
     SCOPES = ['https://www.googleapis.com/auth/presentations.readonly', 'https://www.googleapis.com/auth/presentations', 'https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.appdata','https://www.googleapis.com/auth/drive.file' ]
 
     # The ID of a sample presentation.
 
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -141,8 +140,8 @@ def create_image(presentation_id, new_slide, target_folder_id):
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     try:
         service = build("slides", "v1", credentials=creds)

--- a/main_def/ggl_api/Automate_data_model/get_url.py
+++ b/main_def/ggl_api/Automate_data_model/get_url.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, get_url, to_sheet
 
 import pandas as pd
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/presentations.readonly', 'https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.appdata','https://www.googleapis.com/auth/drive.file']
 
 
@@ -16,12 +16,11 @@ SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googlea
 Prints values from a sample spreadsheet.80
 """
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -31,8 +30,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=8080)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
 service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/Automate_data_model/upload_drive.py
+++ b/main_def/ggl_api/Automate_data_model/upload_drive.py
@@ -1,16 +1,16 @@
 # Cannot use
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from googleapiclient.http import MediaFileUpload
 
 from main_def import MAIN_DIR, credentials, tokens, image_path, target_folder_id
 import os
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly','https://www.googleapis.com/auth/drive.file']
 
 def uploadDrive(image_path,target_folder_id):
@@ -18,12 +18,11 @@ def uploadDrive(image_path,target_folder_id):
     Prints the names and ids of the first 10 files the user has access to.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -33,8 +32,8 @@ def uploadDrive(image_path,target_folder_id):
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('drive', 'v3', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/con_api.py
+++ b/main_def/ggl_api/google_spreadsheet_api/con_api.py
@@ -1,8 +1,8 @@
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 import os.path
-import pickle
 import pandas as pd
 from main_def import credentials, tokens
 
@@ -13,12 +13,11 @@ def service():
     Prints values from a sample spreadsheet.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -28,8 +27,8 @@ def service():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/definitions.py
+++ b/main_def/ggl_api/google_spreadsheet_api/definitions.py
@@ -1,8 +1,8 @@
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 import os.path
-import pickle
 import pandas as pd
 from main_def import credentials, tokens
 
@@ -14,12 +14,11 @@ def service():
     Prints values from a sample spreadsheet.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -29,8 +28,8 @@ def service():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/function.py
+++ b/main_def/ggl_api/google_spreadsheet_api/function.py
@@ -1,8 +1,8 @@
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 import os.path
-import pickle
 import pandas as pd
 from main_def import credentials, tokens
 
@@ -14,12 +14,11 @@ def service():
     Prints values from a sample spreadsheet.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
 
     if not creds or not creds.valid:
@@ -30,8 +29,8 @@ def service():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/quick_drive.py
+++ b/main_def/ggl_api/google_spreadsheet_api/quick_drive.py
@@ -1,13 +1,13 @@
 # Cannot use
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import credentials, tokens
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly']
 
 def main():
@@ -15,12 +15,11 @@ def main():
     Prints the names and ids of the first 10 files the user has access to.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -30,8 +29,8 @@ def main():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('drive', 'v3', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/quick_sheet.py
+++ b/main_def/ggl_api/google_spreadsheet_api/quick_sheet.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -9,7 +8,7 @@ import numpy as np
 
 # https://developers.google.com/sheets/api/quickstart/python
 # https://gspread.readthedocs.io/en/latest/user-guide.html#using-gspread-with-pandas
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
 
 
@@ -18,12 +17,11 @@ def main():
     Prints values from a sample spreadsheet.80
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
+    if os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json')
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -33,8 +31,8 @@ def main():
                 'client_secrets.json', SCOPES)
             creds = flow.run_local_server(port=8080)
         # Save the credentials for the next run
-        with open('token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+        with open('token.json', 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 
@@ -94,12 +92,11 @@ def service():
     Prints values from a sample spreadsheet.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
+    if os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json')
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -109,8 +106,8 @@ def service():
                 'client_secrets.json', SCOPES)
             creds = flow.run_local_server(port=8080)
         # Save the credentials for the next run
-        with open('token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+        with open('token.json', 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/quick_sheet0.py
+++ b/main_def/ggl_api/google_spreadsheet_api/quick_sheet0.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 import pandas
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
 
 
@@ -15,12 +15,11 @@ def main():
     Prints values from a sample spreadsheet.80
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
+    if os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json')
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -30,8 +29,8 @@ def main():
                 'client_secrets.json', SCOPES)
             creds = flow.run_local_server(port=8080)
         # Save the credentials for the next run
-        with open('token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+        with open('token.json', 'w') as token:
+        token.write(creds.to_json())
 
     service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/google_spreadsheet_api/upload_drive.py
+++ b/main_def/ggl_api/google_spreadsheet_api/upload_drive.py
@@ -62,7 +62,7 @@ drive = GoogleDrive(gauth)
 #     Prints values from a sample spreadsheet.
 #     """
 #     creds = None
-#     # The file token.pickle stores the user's access and refresh tokens, and is
+#     # The file token.json stores the user's access and refresh tokens, and is
 #     # created automatically when the authorization flow completes for the first
 #     # time.
 #     if os.path.exists(token_path):

--- a/main_def/ggl_api/kasa/Automate_data_model/copy_sheet_template.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/copy_sheet_template.py
@@ -1,8 +1,8 @@
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, save_path_sheet, title_sheet, title_test_plan
 
 
@@ -13,12 +13,11 @@ SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googlea
 Prints values from a sample spreadsheet.80
 """
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -28,8 +27,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=8080)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
 service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/kasa/Automate_data_model/copy_slide_template.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/copy_slide_template.py
@@ -2,20 +2,18 @@ from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 
 import os
 from main_def import MAIN_DIR, credentials, tokens
-import pickle
-
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly', 'https://www.googleapis.com/auth/drive.file']
 
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -25,8 +23,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=0)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 def copy_presentation(presentation_id, copy_title):
     """
     Creates the copy Presentation the user has access to.

--- a/main_def/ggl_api/kasa/Automate_data_model/create_slide_image.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/create_slide_image.py
@@ -3,10 +3,10 @@ from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, FIX_SLIDE_ID,new_slide, target_folder_id, get_url, slide_image_path
 import csv
 
-import pickle
 import os.path
 import time
 import pandas as pd
@@ -120,18 +120,17 @@ def create_image(presentation_id, new_slide, target_folder_id):
     for guides on implementing OAuth2 for the application.
     """
 
-    # If modifying these scopes, delete the file token.pickle.
+    # If modifying these scopes, delete the file token.json.
     SCOPES = ['https://www.googleapis.com/auth/presentations.readonly', 'https://www.googleapis.com/auth/presentations', 'https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.appdata','https://www.googleapis.com/auth/drive.file' ]
 
     # The ID of a sample presentation.
 
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -141,8 +140,8 @@ def create_image(presentation_id, new_slide, target_folder_id):
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     try:
         service = build("slides", "v1", credentials=creds)

--- a/main_def/ggl_api/kasa/Automate_data_model/get_url.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/get_url.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from main_def import MAIN_DIR, credentials, tokens, get_url, to_sheet
 
 import pandas as pd
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/presentations.readonly', 'https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.appdata','https://www.googleapis.com/auth/drive.file']
 
 
@@ -16,12 +16,11 @@ SCOPES = [ 'https://www.googleapis.com/auth/presentations', 'https://www.googlea
 Prints values from a sample spreadsheet.80
 """
 creds = None
-# The file token.pickle stores the user's access and refresh tokens, and is
+# The file token.json stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
 if os.path.exists(tokens):
-    with open(tokens, 'rb') as token:
-        creds = pickle.load(token)
+    creds = Credentials.from_authorized_user_file(tokens)
 # If there are no (valid) credentials available, let the user log in.
 if not creds or not creds.valid:
     if creds and creds.expired and creds.refresh_token:
@@ -31,8 +30,8 @@ if not creds or not creds.valid:
             credentials, SCOPES)
         creds = flow.run_local_server(port=8080)
     # Save the credentials for the next run
-    with open(tokens, 'wb') as token:
-        pickle.dump(creds, token)
+    with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
 service = build('sheets', 'v4', credentials=creds)
 

--- a/main_def/ggl_api/kasa/Automate_data_model/quick_drive.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/quick_drive.py
@@ -1,15 +1,15 @@
 # Cannot use
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from googleapiclient.http import MediaFileUpload
 
 from main_def import credentials, tokens
 import os
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly','https://www.googleapis.com/auth/drive.file' ]
 
 def main():
@@ -17,12 +17,11 @@ def main():
     Prints the names and ids of the first 10 files the user has access to.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -32,8 +31,8 @@ def main():
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('drive', 'v3', credentials=creds)
 

--- a/main_def/ggl_api/kasa/Automate_data_model/upload_drive.py
+++ b/main_def/ggl_api/kasa/Automate_data_model/upload_drive.py
@@ -1,16 +1,16 @@
 # Cannot use
 from __future__ import print_function
-import pickle
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from googleapiclient.http import MediaFileUpload
 
 from main_def import MAIN_DIR, credentials, tokens, image_path, target_folder_id
 import os
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly','https://www.googleapis.com/auth/drive.file']
 
 def uploadDrive(image_path,target_folder_id):
@@ -18,12 +18,11 @@ def uploadDrive(image_path,target_folder_id):
     Prints the names and ids of the first 10 files the user has access to.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     if os.path.exists(tokens):
-        with open(tokens, 'rb') as token:
-            creds = pickle.load(token)
+        creds = Credentials.from_authorized_user_file(tokens)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -33,8 +32,8 @@ def uploadDrive(image_path,target_folder_id):
                 credentials, SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open(tokens, 'wb') as token:
-            pickle.dump(creds, token)
+        with open(tokens, 'w') as token:
+        token.write(creds.to_json())
 
     service = build('drive', 'v3', credentials=creds)
 

--- a/main_def/ggl_api/kasa/cloudfunc.py
+++ b/main_def/ggl_api/kasa/cloudfunc.py
@@ -16,7 +16,7 @@ from google.oauth2 import service_account
 
 # os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 
-# If modifying these scopes, delete the file token.pickle.
+# If modifying these scopes, delete the file token.json.
 
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive',
           'https://www.googleapis.com/auth/drive.file']


### PR DESCRIPTION
🎯 **What:** The codebase previously used `pickle.load()` and `pickle.dump()` to manage google API credentials in `token.pickle` across multiple automation scripts. This has been updated to use `Credentials.from_authorized_user_file()` and `to_json()` with a `token.json` file.
⚠️ **Risk:** Loading untrusted data with `pickle` can result in Insecure Deserialization, leading to Remote Code Execution (RCE). If an attacker managed to place or modify `token.pickle`, they could execute arbitrary code when the automation scripts ran.
🛡️ **Solution:** Replaced all `pickle` usages for credentials with the built-in, secure `google.oauth2.credentials.Credentials` JSON serialization methods. Changed the target filename to `token.json` so old files are ignored and users will be prompted to re-authenticate securely.

---
*PR created automatically by Jules for task [5643884547627629289](https://jules.google.com/task/5643884547627629289) started by @mrdat0194*